### PR TITLE
Se agrega link Gestionar Autos en NavBar, modificacion en carPanel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,11 @@
 <script setup>
 import { RouterLink, RouterView } from 'vue-router'
 import NavBar from './components/NavBar.vue'
-
 </script>
 
 <template>
     <NavBar/>
     <router-view />
- 
-
- 
 </template>
 
 <style scoped>

--- a/src/components/CarPanelItem.vue
+++ b/src/components/CarPanelItem.vue
@@ -5,13 +5,15 @@
           <div class="details">
             <span class="status" :class="{'rented': estaAlquilado(auto), 'not-rented': !estaAlquilado(auto)}"></span>
             <span class="name">{{ auto.name }}</span>
-            <div v-if="auto.rentedUntil != 0"><span>Alquilado hasta{{ formatedDate(auto.rentedUntil) }}</span></div>
+            <div v-if="auto.rentedUntil != 0"><span>Alquilado hasta {{ formatedDate(auto.rentedUntil) }}</span></div>
             <div v-else> Disponible para alquilar</div>
           </div>
           <div class="buttons">
             <button @click="editar()" class="btn edit-btn">Editar</button>
             <button @click="eliminarAuto()" class="btn delete-btn">Eliminar</button>
-            <button @click="cancelRent()" class="btn delete-btn">Cancelar renta</button>
+
+            <!-- Mostrar el botón cancelRent solo si el auto está alquilado -->
+            <button v-if="estaAlquilado(auto)" @click="cancelRent()" class="btn delete-btn">Cancelar renta</button>
           </div>
         </div>
       

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -10,8 +10,8 @@
         <!--<router-link to="/CrearAuto">Agregar Auto</router-link>-->
         <!-- acá también poner o sacar según sea admin o no -->
         <router-link to="/Home">Home</router-link>
-
-        <router-link to="/CrearAuto" v-if=" esAdmin ">Crear Auto</router-link>
+        <router-link to="/CrearAuto" v-if=" esAdmin ">Agregar Auto</router-link>
+        <router-link to="/CarPanel" v-if=" esAdmin ">Gestionar Autos</router-link>
         <router-link to="/Login" v-if="!estaLogeado">Login</router-link>
         <router-link to="/Perfil" v-if="estaLogeado">Perfil</router-link>
         <button @click="logout" v-if="estaLogeado"type="button">Logout</button>
@@ -34,6 +34,7 @@
   
   <script>
   import { useAuthStore } from '@/stores/userStore';
+
   export default {
     data() {
       return {
@@ -46,27 +47,22 @@
       toggleMenu() {
         this.isActive = !this.isActive;
       },
-
-       logout() {
-          this.store.logout()
-          this.$router.push("Login")
+      logout() {
+        this.store.logout()
+        this.$router.push("Login")
       }, 
-
     },
     computed: {
-
       esAdmin() {
         return this.store.isAdmin
       },
       estaLogeado(){
         return this.store.isAuthenticated
       }
-      
     },
     mounted(){
       this.store.checkAuth()
     }
-
   };
   </script>
   

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,14 +9,11 @@ import Perfil from '@/views/Perfil.vue'
 import CarPanel from '@/views/CarPanel.vue'
 import EditCar from '@/views/EditCar.vue'
 
-
 const routes = [
   {
     path: "/home",
     name:"Home",
     component: Home,
-    
-
   },
   {
     path: '/',
@@ -76,8 +73,6 @@ const routes = [
     },
     props: true
   }
-  
-
 ]
 
 
@@ -95,7 +90,5 @@ router.beforeEach((to, from, next) => {
         next();
     }
 })
- 
-
 
 export default router

--- a/src/views/CrearAuto.vue
+++ b/src/views/CrearAuto.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         
-        <h1>Crear Auto</h1>
+        <h1>Agregar Auto</h1>
         <form @submit.prevent="crearAuto">
             <div>
                 <label for="title">Nombre: </label>
@@ -52,6 +52,13 @@ export default {
             carStore.agregarAuto(nuevoAuto);
             alert('Auto creado con exito')
             this.$router.push({ name: 'Home' })
+        },
+        limpiarFormulario() {
+            this.name = '';
+            this.year = null;
+            this.brand = '';
+            this.price = null;
+            this.imageLink = '';
         }
     }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,7 @@
 <template lang="">
     <CarGallery />
 </template>
+
 <script>
 import CarGallery from '../components/CarGallery.vue'
 export default {
@@ -9,6 +10,7 @@ export default {
     }
 }
 </script>
+
 <style lang="">
     
 </style>


### PR DESCRIPTION
Agregado de link Gestionar Autos en NavBar que lleva a la vista carPanel para editar/eliminar/cancelar renta.
Modificación en CarPanel para que el botón Cancelar renta no aparezca si el auto está alquilado.
Agregado de la funcion limpiarFormulario() luego de que se crea un auto y se agrega a la colección de autos
